### PR TITLE
Set mSignalInfoToneGenerator to null after releasing it.

### DIFF
--- a/src/com/android/phone/CallNotifier.java
+++ b/src/com/android/phone/CallNotifier.java
@@ -981,6 +981,7 @@ public class CallNotifier extends Handler
         // Release the ToneGenerator used for playing SignalInfo and CallWaiting
         if (mSignalInfoToneGenerator != null) {
             mSignalInfoToneGenerator.release();
+            mSignalInfoToneGenerator = null;
         }
 
         // Clear ringback tone player


### PR DESCRIPTION
Set mSignalInfoToneGenerator to null after releasing it, to prevent us from
trying to perform operations on it later after release. This fixes a crash when
making and receiving phonecalls on SCH-i605 (Verizon Galaxy Note II).

[This fixes a crash that happens on my i605 literally every time I try to place or receive a call. I have no idea why nobody else is seeing this. It seems to be a longstanding bug in stock Android, but for some reason was never triggered before. It was introduced in 0fb2b4b8eff811fd3243aefdf536e7ba2b10f4e9 in 2009, and was fixed upstream in January in 338fa8da0fcd762e8ffdc618af57078b8d9b958c (which maybe explains why i605 users running stock aren't hitting it.)]
